### PR TITLE
Add callback_url def

### DIFF
--- a/lib/omniauth/strategies/wantedly.rb
+++ b/lib/omniauth/strategies/wantedly.rb
@@ -27,6 +27,10 @@ module OmniAuth
       def raw_info
         @raw_info ||= access_token.get('/api/auth').parsed
       end
+
+      def callback_url
+        full_host + script_name + callback_path
+      end
     end
   end
 end


### PR DESCRIPTION
## Why
https://github.com/wantedly/corporate-site-rails/pull/524
 `callback_url` methodはwantedly strategyに実装してなかったけど本当は必要だった，oauth2 のstrategyに実装されていたので動いていたが， https://github.com/omniauth/omniauth-oauth2/issues/28 で消され，corporate siteでエラーになってしまっていた

## What
`callback_url` methodを追加
